### PR TITLE
Update stookwijzerapi.py

### DIFF
--- a/stookwijzer/stookwijzerapi.py
+++ b/stookwijzer/stookwijzerapi.py
@@ -92,7 +92,7 @@ class Stookwijzer(object):
         advice = self.get_property("advies_0")
         if advice:
             self._advice = self.get_color(advice)
-            self._alert = self.get_property("alert_0") == "1"
+            self._alert = advice > "0"
             self._last_updated = datetime.now()
 
     def get_forecast_array(self, advice: bool) -> list:


### PR DESCRIPTION
change binary sensor check value to advies_0 > 0. alert_0 does not exist in the new API. Don't know if that's the purpose, since there are 3 stages. green/yellow/red advice (0, 1, 2). If the binary sensor should only trigger on code red, the line has to be changed to "> 1".